### PR TITLE
Issue with activating Bricks in multiple windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/package.json
+++ b/package.json
@@ -80,10 +80,6 @@
         "title": "Open File"
       },
       {
-        "command": "bricksDesignToCode.reset",
-        "title": "Reset Bricks"
-      },
-      {
         "command": "bricksDesignToCode.activate",
         "title": "Activate Bricks"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ const message = {
   noWorkspaceOpened:
     "Open a workspace to start using Bricks Design to Code Tool",
   bricksIsActiveInAnotherWorkspace: (workspace: string) =>
-    `Bricks is already active in workspace: ${workspace}. Please first shut it down.`,
+    `Bricks is already active in workspace ${workspace}, or you have something running on port ${port}. Please shut it down first.`,
 };
 
 /**
@@ -192,7 +192,6 @@ export async function activate(context: vscode.ExtensionContext) {
     Preview.dispose();
     io.removeAllListeners();
     io.close();
-    websocketServer.close();
 
     await context.globalState.update("bricksWorkspace", undefined);
 
@@ -204,8 +203,4 @@ export async function activate(context: vscode.ExtensionContext) {
    * Create a button for activating and shutting down Bricks
    */
   StatusBarItem.initialize();
-}
-
-export async function deactivate(context: vscode.ExtensionContext) {
-  await context.globalState.update("bricksWorkspace", undefined);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ const message = {
   noWorkspaceOpened:
     "Open a workspace to start using Bricks Design to Code Tool",
   bricksIsActiveInAnotherWorkspace: (workspace: string) =>
-    `Bricks is already active in workspace ${workspace}, or you have something running on port ${port}. Please shut it down first.`,
+    `Bricks is already active in workspace "${workspace}", or you have something running on port ${port}. Please shut it down first.`,
 };
 
 /**

--- a/src/preview/server.ts
+++ b/src/preview/server.ts
@@ -112,7 +112,7 @@ export function endServer(): Promise<void> {
         return reject(err);
       }
       server = undefined;
-      console.log("Stopped express server!");
+      console.log("Stopped live preview server!");
       return resolve();
     });
   });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  - Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier --write .`).
-->

## Summary

Trying to use Bricks in multiple VS Code window can be buggy because we're using a lot of global states to track things, and global states don't get updated if a VS Code window is closed unexpectedly. I think it's cleaner to just check if the port is in use.

## How did you test this change?

Installed locally, and tested activating/shutting down Bricks in two windows. Code gets generated at the correct window as expected.
