### PR TITLE
Add export file analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "publish": "vsce publish && npm version patch --force"
   },
   "dependencies": {
+    "@amplitude/analytics-node": "^1.1.4",
     "@types/prettier": "^2.7.2",
     "@types/tcp-port-used": "^1.0.1",
     "autoprefixer": "^10.4.13",
@@ -34,6 +35,7 @@
     "tailwind": "^3.1.0",
     "tailwindcss": "^3.2.4",
     "tcp-port-used": "^1.0.2",
+    "uuid": "^9.0.0",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
@@ -44,6 +46,7 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@types/rimraf": "^2.0.2",
+    "@types/uuid": "^9.0.1",
     "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
@@ -136,6 +139,12 @@
           "type": "boolean",
           "default": true,
           "description": "Change this to false if you don't want the Bricks button to show in the statusbar"
+        },
+        "bricksDesignToCode.uniqueUserID": {
+          "type": "string",
+          "default": "",
+          "description": "Unique user ID for analytics purposes.",
+          "scope": "global"
         }
       }
     }

--- a/src/amplitude.ts
+++ b/src/amplitude.ts
@@ -1,0 +1,36 @@
+import { init, track } from "@amplitude/analytics-node";
+import * as vscode from "vscode";
+import { v4 as uuidv4 } from "uuid";
+
+init("");
+
+export function trackExportFilesFromSaveIcon() {
+  track("export_files_click", { method: "save_icon" }, { user_id: userId });
+}
+
+export function trackExportFilesFromContextMenu() {
+  track("export_files_click", { method: "context_menu" }, { user_id: userId });
+}
+
+let userId = getDefaultUserID();
+
+// Use a randomly generated UUID as user id by default
+function getDefaultUserID(): string {
+  const key = "bricksDesignToCode.uniqueUserID";
+  const globalState = vscode.workspace.getConfiguration().get<string>(key);
+
+  if (globalState) {
+    return globalState;
+  } else {
+    const newUUID = uuidv4();
+    vscode.workspace
+      .getConfiguration()
+      .update(key, newUUID, vscode.ConfigurationTarget.Global);
+    return newUUID;
+  }
+}
+
+// Override default user id with the one from the Figma plugin
+export function setUserId(newUserId: string) {
+  userId = newUserId;
+}

--- a/src/exportFiles.ts
+++ b/src/exportFiles.ts
@@ -3,6 +3,10 @@ import path from "path";
 import * as vscode from "vscode";
 import { Utils } from "vscode-uri";
 import { FileSystemProvider } from "./fileExplorer";
+import {
+  trackExportFilesFromContextMenu,
+  trackExportFilesFromSaveIcon,
+} from "./amplitude";
 
 export const exportFiles =
   (
@@ -49,5 +53,11 @@ export const exportFiles =
       ).fsPath;
 
       await fs.copy(fileUri.fsPath, destinationPath);
+    }
+
+    if (exportAllFiles) {
+      trackExportFilesFromSaveIcon();
+    } else {
+      trackExportFilesFromContextMenu();
     }
   };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { createServer } from "http";
 import { formatFiles, getExtensionFromFilePath } from "./util";
 import { MESSAGE, PORT } from "./constants";
 import { exportFiles } from "./exportFiles";
+import { setUserId } from "./amplitude";
 
 /**
  * Setting up the http server
@@ -142,6 +143,10 @@ export async function activate(context: vscode.ExtensionContext) {
      */
     io.on("connection", (socket) => {
       socket.emit("pong", "pong");
+
+      socket.on("user-id", (userId) => {
+        setUserId(userId);
+      });
 
       socket.on("code-generation", async (data, callback) => {
         try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,28 @@
     deep-eql "^0.1.3"
     keypather "^1.10.2"
 
+"@amplitude/analytics-core@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-0.13.1.tgz#0838b90e3aa86ecfdc3efac498969d6bc247e4b0"
+  integrity sha512-vVlZSo8U2MxTgaXVNeW2kUzj4/5/7E8OZfIW7DUVcLMHowYTjP1utYtCxA1pds+llN6VRT0/5LWyHl5/Mju4Tw==
+  dependencies:
+    "@amplitude/analytics-types" "^0.19.0"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-node@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-node/-/analytics-node-1.1.4.tgz#5e1bd4aa11a0d514bce0016b21b894b97d82b047"
+  integrity sha512-+cghnUGkO1KhRiPGZcMrr4y9FWfZSzST8uvKKGkF9mDjo5/m1EJ0xaVCdkB+Iv2MS1I88QhZiun55hwUQ3o6eg==
+  dependencies:
+    "@amplitude/analytics-core" "^0.13.1"
+    "@amplitude/analytics-types" "^0.19.0"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-types@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-0.19.0.tgz#2864394a1dcd57f84ccfe84388af1444b70943be"
+  integrity sha512-xECFyB40KZdmlvlF76iLp+YO9Tpt2/Ha5S34MrE7Q26gzyTh+vgwGS8FaqYGBzcGeMqKFYDja1hoF/onS94GrA==
+
 "@babel/runtime@7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
@@ -543,6 +565,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/tcp-port-used/-/tcp-port-used-1.0.1.tgz#4e15eada6d9f63a5e6c5ef73348d6023f1e91157"
   integrity sha512-6pwWTx8oUtWvsiZUCrhrK/53MzKVLnuNSSaZILPy3uMes9QnTrLMar9BDlJArbMOjDcjb3QXFk6Rz8qmmuySZw==
+
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
 
 "@types/vscode@^1.74.0":
   version "1.75.1"
@@ -3682,6 +3709,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.4.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tsscmp@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
@@ -3795,6 +3827,11 @@ uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 uuidv4@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  - Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier --write .`).
-->

## Summary

Now amplitude events sent from both VS Code and Figma will use the user id. This is done by sending the Figma user id from the Figma plugin the VS Code.

## How did you test this change?

Generated code in Figma plugin, then exported files from VS Code. Verified on Amplitude that now both events are linked to the same user.