### PR TITLE
Add button to open preview in external browser

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -5,8 +5,118 @@ iframe {
   width: 100%;
 }
 
-iframe {
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+header {
   width: 100%;
+  height: 2.5em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2em;
+}
+
+button#open-preview-in-browser {
+  width: 200px;
+}
+
+iframe {
   border: none;
   background: white; /* Browsers default to a white background */
+}
+
+/* VS Code theme */
+:root {
+  --container-padding: 20px;
+  --input-padding-vertical: 6px;
+  --input-padding-horizontal: 4px;
+  --input-margin-vertical: 4px;
+  --input-margin-horizontal: 0;
+}
+
+body {
+  padding: 0 var(--container-padding);
+  color: var(--vscode-foreground);
+  font-size: var(--vscode-font-size);
+  font-weight: var(--vscode-font-weight);
+  font-family: var(--vscode-font-family);
+  background-color: var(--vscode-editor-background);
+}
+
+ol,
+ul {
+  padding-left: var(--container-padding);
+}
+
+body > *,
+form > * {
+  margin-block-start: var(--input-margin-vertical);
+  margin-block-end: var(--input-margin-vertical);
+}
+
+*:focus {
+  outline-color: var(--vscode-focusBorder) !important;
+}
+
+a {
+  color: var(--vscode-textLink-foreground);
+}
+
+a:hover,
+a:active {
+  color: var(--vscode-textLink-activeForeground);
+}
+
+code {
+  font-size: var(--vscode-editor-font-size);
+  font-family: var(--vscode-editor-font-family);
+}
+
+button {
+  border: none;
+  padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+  width: 100%;
+  text-align: center;
+  outline: 1px solid transparent;
+  outline-offset: 2px !important;
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+}
+
+button:hover {
+  cursor: pointer;
+  background: var(--vscode-button-hoverBackground);
+}
+
+button:focus {
+  outline-color: var(--vscode-focusBorder);
+}
+
+button.secondary {
+  color: var(--vscode-button-secondaryForeground);
+  background: var(--vscode-button-secondaryBackground);
+}
+
+button.secondary:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+input:not([type="checkbox"]),
+textarea {
+  display: block;
+  width: 100%;
+  border: none;
+  font-family: var(--vscode-font-family);
+  padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+  color: var(--vscode-input-foreground);
+  outline-color: var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--vscode-input-placeholderForeground);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,7 @@
 export const PORT = 32044;
 
 export const MESSAGE = {
-  welcome:
-    'To start using Bricks, click "Activate Bricks" in the status bar, or run "Activate Bricks" in the command palette ("View" > "Command Palette").',
+  welcome: 'To start using Bricks, click "Activate Bricks" in the status bar.',
   activated: "Activated! Go to Figma to select a component.",
   noWorkspaceOpened:
     "Open a workspace to start using Bricks Design to Code Tool",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  - Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier --write .`).
-->

## Summary
Added a button to open live preview in an external browser window. Quick fix for #18.

<img width="1512" alt="Screen Shot 2023-05-02 at 11 57 36 AM" src="https://user-images.githubusercontent.com/19992630/235720390-a104010e-2375-4750-b9a9-3561a3f167d7.png">

## How did you test this change?

Verified the button will open the live preview in an external window.